### PR TITLE
Add Python API example

### DIFF
--- a/Python/fundapps-api-example.py
+++ b/Python/fundapps-api-example.py
@@ -1,4 +1,3 @@
-
 import requests as req
 from requests.auth import HTTPBasicAuth
 import xml
@@ -9,30 +8,30 @@ import time
 # PLEASE POPULATE FOUR VARIABLES BELOW TO TEST
 ###########
 
-client_environment = '' 
-api_user = ''
-api_password = '' #NOTE: please be conscious when sharing this file as this password will allow API access
-positions_file = '' # XML or ZIP file
+client_environment  = '' 
+api_user            = ''
+api_password        = '' # NOTE: please be conscious when sharing this file as this password will allow API access
+positions_file      = '' # XML or ZIP file
 
 ###########
 
-base_url = 'https://{}-api.fundapps.co'.format(client_environment)
-auth=HTTPBasicAuth(api_user, api_password)
+base_url = f'https://{client_environment}-api.fundapps.co'
+auth = HTTPBasicAuth(api_user, api_password)
 files = {'file': (positions_file, open(positions_file, 'rb'), 'text/XML')}
-r = req.post('{}/v1/expost/check'.format(base_url), auth=auth, files=files)
+r = req.post(f'{base_url}/v1/expost/check', auth=auth, files=files)
 
 if r.status_code == 202:
     print('File accepted.')
     xml_response = ElementTree.fromstring(r.content)
-    result_tracking_url = xml_response[0].text
-    r = req.get('{}{}'.format(base_url, result_tracking_url), auth=auth)
-    print(r.status_code)
+    result_tracking_url = f'{base_url}{xml_response[0].text}'
+
+    r = req.get(result_tracking_url, auth=auth)
+    
     while r.status_code == 202:
         print('Upload in progress. Waiting 20 seconds before checking again.')
         time.sleep(20)
-        r = req.get('{}{}'.format(base_url, result_tracking_url), auth=auth)
+        r = req.get(result_tracking_url, auth=auth)
         
-    print('Upload complete. Result XML:')
-    print(r.text)
+    print('Upload complete. Result XML:\n', r.text)
 else:
-    print('Unexpected response from FundApps API. HTTP Status code:{}, reason:{}'.format(r.status_code, r.reason))
+    print(f'Unexpected error response from FundApps API. HTTP Status code:{r.status_code}, reason:{r.reason}')

--- a/Python/fundapps-api-example.py
+++ b/Python/fundapps-api-example.py
@@ -1,0 +1,38 @@
+
+import requests as req
+from requests.auth import HTTPBasicAuth
+import xml
+from xml.etree import ElementTree
+import time
+
+############
+# PLEASE POPULATE FOUR VARIABLES BELOW TO TEST
+###########
+
+client_environment = '' 
+api_user = ''
+api_password = '' #NOTE: please be conscious when sharing this file as this password will allow API access
+positions_file = '' # XML or ZIP file
+
+###########
+
+base_url = 'https://{}-api.fundapps.co'.format(client_environment)
+auth=HTTPBasicAuth(api_user, api_password)
+files = {'file': (positions_file, open(positions_file, 'rb'), 'text/XML')}
+r = req.post('{}/v1/expost/check'.format(base_url), auth=auth, files=files)
+
+if r.status_code == 202:
+    print('File accepted.')
+    xml_response = ElementTree.fromstring(r.content)
+    result_tracking_url = xml_response[0].text
+    r = req.get('{}{}'.format(base_url, result_tracking_url), auth=auth)
+    print(r.status_code)
+    while r.status_code == 202:
+        print('Upload in progress. Waiting 20 seconds before checking again.')
+        time.sleep(20)
+        r = req.get('{}{}'.format(base_url, result_tracking_url), auth=auth)
+        
+    print('Upload complete. Result XML:')
+    print(r.text)
+else:
+    print('Unexpected response from FundApps API. HTTP Status code:{}, reason:{}'.format(r.status_code, r.reason))


### PR DESCRIPTION
To run this file, users need to have the packages `requests` and `xml` installed.
The sample uploads a file, then checks file status every 20 seconds.

I tested this manually to exercise happy and failure path, by uploading a file against master-staging.

Console output below - first invocation fails due to not having credentials. 
Second one succeeds and shows the 20 second delay, and output of results:

![image](https://user-images.githubusercontent.com/4528472/77336501-815d2380-6d1f-11ea-8279-4b6af9a3a1a2.png)

