### PR TITLE
Update Docs for Portfolio Status Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ The Summary element is comprised of:
  * The total number of alerts by type - i.e. Breach, Unknown, etc.
  * The number of new alerts by type (since the day before).
 
+You cannot check the progress of a portfolio file upload because these files load too quickly. Instead, when you upload a portfolio file, it will return a status immediately of any of the following:
+
+ValidationState  | Explanation  
+-----------------|-------------
+Uploaded         | Succesfully uploaded    
+Validation       | Validation failure
+No input document| No file attached to API call     
+Unexpected Error | Error in file upload  
+
+
 #### Sample
     (Request)
     GET https://%company%-api.fundapps.co/v1/ExPost/Result/fe633307-f196-4609-abfe-a1fc0111e875 HTTP/1.1

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ The Summary element is comprised of:
 
 You cannot check the progress of a portfolio file upload because these files load too quickly. Instead, when you upload a portfolio file, it will return a status immediately of any of the following:
 
-ValidationState  | Explanation  
------------------|-------------
-Uploaded         | Succesfully uploaded    
-Validation       | Validation failure
-No input document| No file attached to API call     
-Unexpected Error | Error in file upload  
+ValidationState   | Explanation  
+------------------|-------------
+Uploaded          | Succesfully uploaded    
+Validation failure| File did not pass validation
+No input document | No file attached to API call     
+Unexpected Error  | Error in file upload  
 
 
 #### Sample

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The Summary element is comprised of:
  * The total number of alerts by type - i.e. Breach, Unknown, etc.
  * The number of new alerts by type (since the day before).
 
-You cannot check the progress of a portfolio file upload because these files load too quickly. Instead, when you upload a portfolio file, it will return a status immediately of any of the following:
+You cannot check the progress of a portfolio file upload. Instead, when you upload a portfolio file, it will return a status immediately of any of the following:
 
 ValidationState   | Explanation  
 ------------------|-------------


### PR DESCRIPTION
To inform clients you can't call the status of a portfolio file via the API.