### PR TITLE
AddCommoditySymbolAndDeliveryMonthToSampleFutureXML

### DIFF
--- a/Sample-XML/Future on a Bond Index.xml
+++ b/Sample-XML/Future on a Bond Index.xml
@@ -7,7 +7,7 @@
             <Component InstrumentId="FI0009000681" Weighting="0.7"/>
             <Component InstrumentId="GB00BH4HKS39" Weighting="0.3"/>
         </Index>
-        <Future InstrumentId="BondIndexFuture" InstrumentName="MSCI EAFE Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL" ContractSize="100" CUSIP="123456789" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="2000" InstrumentCurrency="USD">
+        <Future InstrumentId="BondIndexFuture" InstrumentName="MSCI EAFE Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL" ContractSize="100" CUSIP="123456789" CommoditySymbol="MSF" DeliveryMonth="2018-12" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="2000" InstrumentCurrency="USD">
             <Component InstrumentId="MSCI"/>
         </Future> 
     </Instruments>

--- a/Sample-XML/Future on a Bond.xml
+++ b/Sample-XML/Future on a Bond.xml
@@ -2,7 +2,7 @@
 <Snapshot Date="2018-08-30">
     <Instruments>
         <Bond InstrumentId="Evil Bond" Instrumentname="Evil Corporate Bond" IssuerId="EvilCorp" IssuerName="Evil Corporation" CountryOfIssue="GB" CUSIP="123456789" FaceValue="1000" ISIN="ABC123456789"  Market="XLON" MarketsListedIn="XLON" TitleOfClass="EVIL"/>
-        <Future InstrumentId="BondFuture" InstrumentName="Evil Bond Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL" CUSIP="123456789" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="3000">
+        <Future InstrumentId="BondFuture" InstrumentName="Evil Bond Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL" CUSIP="123456789" CommoditySymbol="ZBM1" DeliveryMonth="2018-12" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="3000">
             <Component InstrumentId="Evil Bond"/>
         </Future> 
     </Instruments>

--- a/Sample-XML/Future on an Equity Index.xml
+++ b/Sample-XML/Future on an Equity Index.xml
@@ -7,7 +7,7 @@
             <Component InstrumentId="FI0009000681" Weighting="0.7"/>
             <Component InstrumentId="GB00BH4HKS39" Weighting="0.3"/>
         </Index>
-        <Future InstrumentId="MSCIEAFEFuture" InstrumentName="MSCI EAFE Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL"  ContractSize="100" CUSIP="123456789" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="3000">
+        <Future InstrumentId="MSCIEAFEFuture" InstrumentName="MSCI EAFE Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL"  ContractSize="100" CUSIP="123456789" CommoditySymbol="MSF" DeliveryMonth="2018-12" MaturityDate="2018-12-15" ExercisePrice="3120" Notional="3000">
             <Component InstrumentId="MSCI"/>
         </Future> 
     </Instruments>

--- a/Sample-XML/Multiple Asset Classes.xml
+++ b/Sample-XML/Multiple Asset Classes.xml
@@ -28,7 +28,7 @@
     <Swap InstrumentId="Swap_Nokia" InstrumentName="Nokia Swap" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL">
       <Component InstrumentId="FI0009000681"/>
     </Swap>
-    <Future InstrumentId="Fut_STOXX_600" InstrumentName="STOXX 600 SXXP Index Future" IsCashSettled="true" ContractSize="10" Market="XHEL" MarketsListedIn="XHEL">
+    <Future InstrumentId="Fut_STOXX_600" InstrumentName="STOXX 600 SXXP Index Future" ISIN="FUT900090001" IsCashSettled="true" Market="XHEL" MarketsListedIn="XHEL"  ContractSize="100" CUSIP="123456789" CommoditySymbol="FXXP" DeliveryMonth="2015-12" MaturityDate="2015-12-15" ExercisePrice="3120" Notional="3000">
       <Component InstrumentId="SXXP"/>
     </Future>
     <Index InstrumentId="SXXP" InstrumentName="STOXX 600" Price="3120.00" InstrumentCurrency="EUR">


### PR DESCRIPTION
CommoditySymbol and DeliveryMonth are two properties required to pass validation for Future which are missing from current Future XML samples.